### PR TITLE
Dockerize TritonSizer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.gitignore
+.gitmodules
+Dockerfile
+README.md
+TODO.md
+doc

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ ENV CC=/opt/rh/devtoolset-7/root/usr/bin/gcc \
     PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
 
 # install dependencies 
-RUN yum install -y wget libstdc++-devel libstdc++-static libX11-devel \
-    boost-devel zlib-devel tcl-devel autoconf automake swig flex libtool
+RUN yum install -y wget libstdc++-devel libstdc++-static libX11-devel yacc byacc \
+    boost-devel zlib-devel tcl tcl-devel autoconf automake swig flex libtool
 
 # add source code
 COPY . TritonSizer
@@ -19,9 +19,10 @@ COPY . TritonSizer
 # install TritonSizer 
 RUN cd TritonSizer && \
     make clean && \
-    make && \
-    source load.sh
+    make
+ENV LD_LIBRARY_PATH=/TritonSizer/module/tcl/unix/install-sp/lib
 
-# test installation
-RUN cd TritonSizer/src && \
-    sizer --help
+# set working directory
+WORKDIR TritonSizer/src
+
+ENTRYPOINT ["/TritonSizer/src/sizer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM centos:6
+LABEL maintainer="Abdelrahman Hosny <abdelrahman@brown.edu>" 
+
+# install gcc 7
+RUN yum -y install centos-release-scl && \
+    yum -y install devtoolset-7 devtoolset-7-libatomic-devel
+ENV CC=/opt/rh/devtoolset-7/root/usr/bin/gcc \
+    CPP=/opt/rh/devtoolset-7/root/usr/bin/cpp \
+    CXX=/opt/rh/devtoolset-7/root/usr/bin/g++ \
+    PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH
+
+# install dependencies 
+RUN yum install -y wget libstdc++-devel libstdc++-static libX11-devel \
+    boost-devel zlib-devel tcl-devel autoconf automake swig flex libtool
+
+# add source code
+COPY . TritonSizer
+
+# install TritonSizer 
+RUN cd TritonSizer && \
+    make clean && \
+    make && \
+    source load.sh
+
+# test installation
+RUN cd TritonSizer/src && \
+    sizer --help


### PR DESCRIPTION
This pull request proposes to dockerize TritonSizer. To build the Docker image: `docker build -t tritonsizer .` To use the image, mount the directory where you have your input files to a directory inside the container (e.g. `/data`). Run TritonSizer as following:

`docker run -it -v $(pwd):/data tritonsizer -env <environment file> -f <command file> | tee log`

To try without building the image locally, use image name `openroad/tritonsizer` on Docker Hub: https://hub.docker.com/r/openroad/tritonsizer